### PR TITLE
Integration test and console.error

### DIFF
--- a/src/SpurString.js
+++ b/src/SpurString.js
@@ -22,9 +22,9 @@ class SpurString {
       });
 
       this.loadPluginsByObject(pluginsObject);
+    } else {
+      console.error(`Plugin path "${folderPath}" was not found`);
     }
-
-    console.error(`Plugin path "${folderPath}" was not found`);
   }
 
   loadPluginsByObject(pluginsObject) {

--- a/test/integration/ModuleIntegration_Spec.js
+++ b/test/integration/ModuleIntegration_Spec.js
@@ -1,5 +1,5 @@
 // NEED to use require vs import to test module export for backward compatability
-const mainModule = require('../../');
+const mainModule = require('../../src/SpurString');
 
 describe('Integration', () => {
   describe('Main Module Integration Tests', () => {


### PR DESCRIPTION
- Pointed the require module to the correction path
- Show console error only if path is not found. Currently it shows console.error regardlessly